### PR TITLE
Performance

### DIFF
--- a/src/cluster_challenge/matching/clevar_matching.py
+++ b/src/cluster_challenge/matching/clevar_matching.py
@@ -117,7 +117,7 @@ if mt_method == 'proximity' :
 	mt = ProximityMatch()
 
 	delta_z = float(cfg['matching']['delta_z'])
-	match_radius = float(cfg['matching']['delta_z'])	## in Mpc
+	match_radius = float(cfg['matching']['match_radius'])	## in Mpc
 	match_config = {
 		'type':'cross',			## OPTIONS: cross, cat1, cat2
 		'which_radius':'max',		## OPTIONS: cat1, cat2, min, max

--- a/src/cluster_challenge/matching/matching.py
+++ b/src/cluster_challenge/matching/matching.py
@@ -5,7 +5,7 @@ import os, sys, yaml
 current_dir = os.path.dirname(__file__)
 
 
-def slurm_submit(task, config) :#cat1, cat2, mt_method, mt_pref, mt_params) :
+def slurm_submit(task, config) :
 	slurm_mem = 32
 	time.sleep(5)
 
@@ -55,43 +55,4 @@ def slurm_submit(task, config) :#cat1, cat2, mt_method, mt_pref, mt_params) :
 config_file = sys.argv[1]
 
 slurm_submit('clevar_matching', config_file)
-
-### MATCH COSMODC2 AND WAZP.COSMODC2.TRUEZ
-#slurm_submit('clevar_matching', 'cosmoDC2_v0', 'wazp_cosmoDC2.truez_v0', 'proximity', 'more_massive', [0.05, 1])
-#slurm_submit('clevar_matching', 'cosmoDC2_v0', 'wazp_cosmoDC2.truez_v0', 'proximity', 'angular_proximity', [0.05, 1])
-#slurm_submit('clevar_matching', 'cosmoDC2_v0', 'wazp_cosmoDC2.truez_v0', 'member', 'more_massive', [0.0])
-#slurm_submit('clevar_matching', 'cosmoDC2_v0', 'wazp_cosmoDC2.truez_v0', 'member', 'more_massive', [0.1])
-#slurm_submit('clevar_matching', 'cosmoDC2_v0', 'wazp_cosmoDC2.truez_v0', 'member', 'shared_member_fraction', [0.0])
-#slurm_submit('clevar_matching', 'cosmoDC2_v0', 'wazp_cosmoDC2.truez_v0', 'member', 'shared_member_fraction', [0.1])
-
-
-### MATCH COSMODC2 AND WAZP.COSMODC2.FZB
-#slurm_submit('clevar_matching', 'cosmoDC2_v0', 'wazp_cosmoDC2.fzb_v0', 'proximity', 'more_massive', [0.05, 1])
-#slurm_submit('clevar_matching', 'cosmoDC2_v0', 'wazp_cosmoDC2.fzb_v0', 'proximity', 'angular_proximity', [0.05, 1])
-#slurm_submit('clevar_matching', 'cosmoDC2_v0', 'wazp_cosmoDC2.fzb_v0', 'member', 'more_massive', [0.0])
-#slurm_submit('clevar_matching', 'cosmoDC2_v0', 'wazp_cosmoDC2.fzb_v0', 'member', 'more_massive', [0.1])
-#slurm_submit('clevar_matching', 'cosmoDC2_v0', 'wazp_cosmoDC2.fzb_v0', 'member', 'shared_member_fraction', [0.0])
-#slurm_submit('clevar_matching', 'cosmoDC2_v0', 'wazp_cosmoDC2.fzb_v0', 'member', 'shared_member_fraction', [0.1])
-
-### MATCH COSMODC2 AND PYWAZP.COSMODC2.TRUEZ
-#slurm_submit('clevar_matching', 'cosmoDC2_v0', 'pywazp_cosmoDC2.truez_v0', 'proximity', 'more_massive', [0.05, 1])
-
-### MATCH COSMODC2 AND WAZP.DC2.FZB
-#slurm_submit('clevar_matching', 'cosmoDC2_v0', 'wazp_DC2.fzb_v0', 'proximity', 'more_massive', [0.05, 1])
-#slurm_submit('clevar_matching', 'cosmoDC2_v0', 'wazp_DC2.fzb_v0', 'proximity', 'angular_proximity', [0.05, 1])
-#
-#
-### MATCH COSMODC2 AND REDMAPPER.COSMODC2
-#slurm_submit('clevar_matching', 'cosmoDC2_v0', 'redmapper_cosmoDC2_v0', 'proximity', 'more_massive', [0.05, 1])
-#slurm_submit('clevar_matching', 'cosmoDC2_v0', 'redmapper_cosmoDC2_v0', 'proximity', 'angular_proximity', [0.05, 1])
-#slurm_submit('clevar_matching', 'cosmoDC2_v0', 'redmapper_cosmoDC2_v0', 'member', 'more_massive', [0.0])
-#slurm_submit('clevar_matching', 'cosmoDC2_v0', 'redmapper_cosmoDC2_v0', 'member', 'more_massive', [0.1])
-#slurm_submit('clevar_matching', 'cosmoDC2_v0', 'redmapper_cosmoDC2_v0', 'member', 'shared_member_fraction', [0.0])
-#slurm_submit('clevar_matching', 'cosmoDC2_v0', 'redmapper_cosmoDC2_v0', 'member', 'shared_member_fraction', [0.1])
-#
-#
-### MATCH COSMODC2 AND REDMAPPER.DC2
-#slurm_submit('clevar_matching', 'cosmoDC2_v0', 'redmapper_DC2_v0', 'proximity', 'more_massive', [0.05, 1])
-#slurm_submit('clevar_matching', 'cosmoDC2_v0', 'redmapper_DC2_v0', 'proximity', 'angular_proximity', [0.05, 1])
-
 

--- a/src/cluster_challenge/performance/mass_richness.py
+++ b/src/cluster_challenge/performance/mass_richness.py
@@ -23,17 +23,18 @@ config = sys.argv[1]
 with open(config) as fstream:
 	cfg = yaml.safe_load(fstream)
 
-cat1 = cfg['cats']['cat1'],
-cat2 = cfg['cats']['cat2'],
-mt_method = cfg['matching']['method'],
-mt_pref = cfg['matching']['pref'],
+cat1 = cfg['cats']['cat1']
+cat2 = cfg['cats']['cat2']
+mt_method = cfg['matching']['method']
+mt_pref = cfg['matching']['pref']
 if mt_method == 'member' :
 	mt_params = [cfg['matching']['minimum_share_fraction']]
 else :
 	mt_params = [cfg['matching']['delta_z'], cfg['matching']['match_radius']]
 
 inpath = sfigs.make_path(cat1, cat2, mt_method, mt_pref, mt_params, base=cfg['paths']['performance']['in'])
-outpath = sfigs.make_path(cat1, cat2, mt_method, mt_pref, mt_params, base=cfg['paths']['performance']['out'])
+outpath = sfigs.make_path(cat1, cat2, mt_method, mt_pref, mt_params, base=cfg['paths']['performance']['out'],
+	addon='mass_richness')
 
 
 
@@ -42,8 +43,10 @@ cltags = cfg['merged_keys']
 try :
 	mtcats = ClCatalog.read(f"{inpath}{cat1}_{cat2}_merged.fits", 'merged', tags=cltags)
 except :
+	cats = {cat1: ClCatalog.read_full(f"{inpath}{cat1}.fits"),
+		cat2: ClCatalog.read_full(f"{inpath}{cat2}.fits")}
 	output_matched_catalog(f"{inpath}{cat1}.fits", f"{inpath}{cat2}.fits", f"{inpath}{cat1}_{cat2}_merged.fits",
-		cats[0], cats[1], matching_type='cross', overwrite=True)
+		cats[cat1], cats[cat2], matching_type='cross', overwrite=True)
 	mtcats = ClCatalog.read(f"{inpath}{cat1}_{cat2}_merged.fits", 'merged', tags=cltags)
 
 

--- a/src/cluster_challenge/performance/matching_metrics.py
+++ b/src/cluster_challenge/performance/matching_metrics.py
@@ -25,29 +25,23 @@ config = sys.argv[1]
 with open(config) as fstream:
 	cfg = yaml.safe_load(fstream)
 
-inpath = sfigs.make_path(
-	cat1 = cfg['cats']['cat1'],
-	cat2 = cfg['cats']['cat2'],
-	mt_method = cfg['matching']['method'],
-	mt_pref = cfg['matching']['pref'],
-	mt_params = cfg['matching']['params'],
-	base = cfg['paths']['performance']['in']
-)
-
-outpath = sfigs.make_path(
-	cat1 = cfg['cats']['cat1'],
-	cat2 = cfg['cats']['cat2'],
-	mt_method = cfg['matching']['method'],
-	mt_pref = cfg['matching']['pref'],
-	mt_params = cfg['matching']['params'],
-	base = cfg['paths']['performance']['out'],
-)
-
-
-## Select the catalogs.
 cat1 = cfg['cats']['cat1']
 cat2 = cfg['cats']['cat2']
+mt_method = cfg['matching']['method']
+mt_pref = cfg['matching']['pref']
+if mt_method == 'member' :
+        mt_params = [cfg['matching']['minimum_share_fraction']]
+else :
+        mt_params = [cfg['matching']['delta_z'], cfg['matching']['match_radius']]
 
+inpath = sfigs.make_path(cat1, cat2, mt_method, mt_pref, mt_params, base=cfg['paths']['performance']['in'])
+outpath = sfigs.make_path(cat1, cat2, mt_method, mt_pref, mt_params, base=cfg['paths']['performance']['out'],
+        addon='matching_metrics')
+
+
+
+
+## read the catalogs.
 cats = {cat1: ClCatalog.read_full(f"{inpath}{cat1}.fits"),
 	cat2: ClCatalog.read_full(f"{inpath}{cat2}.fits")}
 

--- a/src/cluster_challenge/performance/redshift.py
+++ b/src/cluster_challenge/performance/redshift.py
@@ -25,28 +25,19 @@ config = sys.argv[1]
 with open(config) as fstream:
 	cfg = yaml.safe_load(fstream)
 
-inpath = sfigs.make_path(
-	cat1 = cfg['cats']['cat1'],
-	cat2 = cfg['cats']['cat2'],
-	mt_method = cfg['matching']['method'],
-	mt_pref = cfg['matching']['pref'],
-	mt_params = cfg['matching']['params'],
-	base = cfg['paths']['performance']['in']
-)
-
-outpath = sfigs.make_path(
-	cat1 = cfg['cats']['cat1'],
-	cat2 = cfg['cats']['cat2'],
-	mt_method = cfg['matching']['method'],
-	mt_pref = cfg['matching']['pref'],
-	mt_params = cfg['matching']['params'],
-	base = cfg['paths']['performance']['out'],
-)
-
-
-## Select the catalogs.
 cat1 = cfg['cats']['cat1']
 cat2 = cfg['cats']['cat2']
+mt_method = cfg['matching']['method']
+mt_pref = cfg['matching']['pref']
+if mt_method == 'member' :
+        mt_params = [cfg['matching']['minimum_share_fraction']]
+else :
+        mt_params = [cfg['matching']['delta_z'], cfg['matching']['match_radius']]
+
+inpath = sfigs.make_path(cat1, cat2, mt_method, mt_pref, mt_params, base=cfg['paths']['performance']['in'])
+outpath = sfigs.make_path(cat1, cat2, mt_method, mt_pref, mt_params, base=cfg['paths']['performance']['out'],
+        addon='redshift')
+
 
 
 ## Create a merged catalog for the cross-matched pairs if it does not already exist.
@@ -54,8 +45,10 @@ cltags = cfg['merged_keys']
 try :
 	mtcats = ClCatalog.read(f"{inpath}{cat1}_{cat2}_merged.fits", 'merged', tags=cltags)
 except :
+	cats = {cat1: ClCatalog.read_full(f"{inpath}{cat1}.fits"),
+		cat2: ClCatalog.read_full(f"{inpath}{cat2}.fits")}
 	output_matched_catalog(f"{inpath}{cat1}.fits", f"{inpath}{cat2}.fits", f"{inpath}{cat1}_{cat2}_merged.fits",
-		cats[0], cats[1], matching_type='cross', overwrite=True)
+		cats[cat1], cats[cat2], matching_type='cross', overwrite=True)
 	mtcats = ClCatalog.read(f"{inpath}{cat1}_{cat2}_merged.fits", 'merged', tags=cltags)
 
 


### PR DESCRIPTION
An extra comma was present in `performance/mass_richness.py`, `performance/redshift.py`, and `performance/matching_metrics.py` when reading from the config files. This caused the values to be read in as tuples instead of the intended dataType.

Also, in `matching/clevar_matching.py` the `match_radius` was being read in wrong from the config file.

These have now been corrected.